### PR TITLE
ENH Remove count from top bits

### DIFF
--- a/src/index.cpp
+++ b/src/index.cpp
@@ -234,7 +234,6 @@ void StrobemerIndex::populate(float f, size_t n_threads) {
                 occur_once = true;
             }
 
-            randstrobes_vector[position - count].hash = (prev_hash & hash_mask) | ((uint64_t)count << (64 - N));
             if (count > 100){
                 tot_high_ab++;
                 strobemer_counts.push_back(count);
@@ -266,7 +265,6 @@ void StrobemerIndex::populate(float f, size_t n_threads) {
                 tot_mid_ab++;
                 strobemer_counts.push_back(count);
             }
-            randstrobes_vector[position - (count - 1)].hash = (prev_hash & hash_mask) | ((uint64_t)count << (64 - N));
             for (unsigned int index_temp = prev_hash_N + 1; index_temp < (1 << N); index_temp++){
                     hash_positions.push_back(randstrobes_vector.size());
             }
@@ -416,3 +414,27 @@ void StrobemerIndex::print_diagnostics(const std::string& logfile_name, int k) c
     double fraction_masked = 1.0 - (double) tot_seed_count_1000_limit/ (double) tot_seed_count;
     log_file << median << ',' << tot_seed_count << ',' << e_hits << ',' << 100*fraction_masked << std::endl;
 }
+
+unsigned int StrobemerIndex::get_count_line_search(const unsigned int position) const {
+    const auto hash = get_hash(position);
+
+    unsigned int count = 0;
+    // step can be any number that is a power of 2, but a large number works
+    // very well
+    unsigned int step = 512;
+    while (get_hash(position + count + step) == hash) {
+        count += step;
+        step *= 2;
+    }
+    while (step > 1) {
+        while (get_hash(position + count + step) == hash) {
+            count += step;
+        }
+        step /= 2;
+    }
+    while (get_hash(position + count) == hash) {
+        ++count;
+    }
+    return count;
+}
+

--- a/src/nam.cpp
+++ b/src/nam.cpp
@@ -22,29 +22,13 @@ void add_to_hits_per_ref(
     unsigned int position,
     int min_diff
 ) {
-    // Determine whether the hash table’s value directly represents a
-    // ReferenceMer (this is the case if count==1) or an offset/count
-    // pair that refers to entries in the flat_vector.
-
-    unsigned int count = index.get_count(position);
-    if (count == 1) {
-        // auto r = randstrobe_map_entry.as_ref_randstrobe();
-        int ref_s = index.get_strob1_position(position);
+    for (const auto hash = index.get_hash(position); index.get_hash(position) == hash; ++position) {
+        int ref_s = index.get_strobe1_position(position);
         int ref_e = ref_s + index.strobe2_offset(position) + index.k();
         int diff = std::abs((query_e - query_s) - (ref_e - ref_s));
         if (diff <= min_diff) {
             hits_per_ref[index.reference_index(position)].push_back(Hit{query_s, query_e, ref_s, ref_e, is_rc});
             min_diff = diff;
-        }
-    } else {
-        for (unsigned int j = position; j < position + count; ++j) {
-            int ref_s = index.get_strob1_position(j);
-            int ref_e = ref_s + index.strobe2_offset(j) + index.k();
-            int diff = std::abs((query_e - query_s) - (ref_e - ref_s));
-            if (diff <= min_diff) {
-                hits_per_ref[index.reference_index(j)].push_back(Hit{query_s, query_e, ref_s, ref_e, is_rc});
-                min_diff = diff;
-            }
         }
     }
 }
@@ -181,10 +165,7 @@ std::pair<float, std::vector<Nam>> find_nams(
         unsigned int position = index.find(q.hash);
         if (position != -1){
             total_hits++;
-            unsigned int count = index.get_count(position);
-            if (count > index.filter_cutoff){
-                continue;
-            } 
+            if (index.get_hash(position + index.filter_cutoff) == q.hash) { continue; }
             nr_good_hits++;
             add_to_hits_per_ref(hits_per_ref, q.start, q.end, q.is_reverse, index, position, 100'000);
         }


### PR DESCRIPTION
Faster get_count (use O(log N) algorithm instead of linear search) and avoid calling it if possible.

I could not get a good benchmark for this: the variation in calling `strobealign` multiple times is too large, but I know you have some prepared. Can you check if it is slower than the version with the count?